### PR TITLE
[#137] Testing with debian buster failing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ install:
 env:
   jobs:
     - DOCKER_IMAGE_BASE=idealista/jdk:8u252-stretch-openjdk-headless
-    - DOCKER_IMAGE_BASE=idealista/jdk:11.0.7-buster-openjdk-headless
+    - DOCKER_IMAGE_BASE=idealista/jdk:11.0.12-buster-openjdk-headless
     - DOCKER_IMAGE_BASE=idealista/jdk:11.0.6-stretch-openjdk-headless
     - DOCKER_IMAGE_BASE=idealista/jdk:8u252-focal-openjdk-headless
     - DOCKER_IMAGE_BASE=idealista/jdk:14.0.1-focal-openjdk-headless

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased](https://github.com/idealista/solr_role/tree/develop)
+### Changed
+- *Default version as 8.9.0* @sorobon
+### Fixed
+- *[#137] Testing with debian buster failing* @sorobon
 
 ## [3.0.0](https://github.com/idealista/solr_role/tree/3.0.0) (2021-03-17)
 ### Added

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 
 ## General
-solr_version: 8.8.1
+solr_version: 8.9.0
 solr_install: true
 solr_mode: cloud  # standalone|cloud
 

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -29,7 +29,7 @@ platforms:
 
   - name: solrcloud1
     hostname: solrcloud1
-    image: ${DOCKER_IMAGE_BASE:-idealista/jdk:11.0.7-buster-openjdk-headless}
+    image: ${DOCKER_IMAGE_BASE:-idealista/jdk:11.0.12-buster-openjdk-headless}
     privileged: false
     capabilities:
       - SYS_ADMIN
@@ -54,7 +54,7 @@ platforms:
 
   - name: solrcloud2
     hostname: solrcloud2
-    image: ${DOCKER_IMAGE_BASE:-idealista/jdk:11.0.7-buster-openjdk-headless}
+    image: ${DOCKER_IMAGE_BASE:-idealista/jdk:11.0.12-buster-openjdk-headless}
     privileged: false
     capabilities:
       - SYS_ADMIN

--- a/molecule/standalone/molecule.yml
+++ b/molecule/standalone/molecule.yml
@@ -10,7 +10,7 @@ lint: |
 platforms:
   - name: solr1
     hostname: solr1
-    image: ${DOCKER_IMAGE_BASE:-idealista/jdk:11.0.7-buster-openjdk-headless}
+    image: ${DOCKER_IMAGE_BASE:-idealista/jdk:11.0.12-buster-openjdk-headless}
     privileged: false
     capabilities:
       - SYS_ADMIN


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions
* Remember to set **idealista:develop** as base branch;

### Description of the Change

Running molecule tests using debian based images are failing since debian 11 release date

### Applicable Issues

[#137]
