### PR TITLE
#154 fix the task with tag solr_collections runs on all hosts instead…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased](https://github.com/idealista/solr_role/tree/develop)
+### Fixed
+- *[#154](https://github.com/idealista/solr_role/issues/154) fix task with tag solr_collections running on all hosts when the play set the batch size with serial 1* @ajiang
 
 ## [3.0.3](https://github.com/idealista/solr_role/tree/3.0.3) (2022-01-26)
 ### Added

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -36,7 +36,7 @@
 
 - name: Solr | Manage collections
   import_tasks: collections.yml
-  when: solr_collections is defined and solr_collections|length > 0 and solr_mode == 'cloud'
+  when: solr_collections is defined and solr_collections|length > 0 and solr_mode == 'cloud' and ansible_play_hosts_all|length > 0 and inventory_hostname == ansible_play_hosts_all[0]
   run_once: true
   tags:
     - solr_collections


### PR DESCRIPTION
… of one when the play set the batch size with serial 1


### Description of the Change

According to the [doc of ansible](https://docs.ansible.com/ansible/latest/user_guide/playbooks_strategies.html#running-on-a-single-machine-with-run-once), use condition `when: inventory_hostname == ansible_play_hosts_all[0]`.


### Benefits

fix the task with tag solr_collections runs on all hosts when the play set with serial 1

### Possible Drawbacks

Nothing

### Applicable Issues

#154 
